### PR TITLE
Make Rapiro unhappy on command failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.DS_Store
+node_modules

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Playing around with Rapiro
   - Check the battery fully charged.
 - Can't connect SSH into Raspberry Pi
   - Have you connected soon from Raspberry Pi turned on? Please wait abont 1 minute.
-  
+
 ## API
 See [here](http://cylonjs.com/documentation/drivers/rapiro/).
 
@@ -52,3 +52,11 @@ See [here](http://cylonjs.com/documentation/drivers/rapiro/).
 - Use [Zsh](http://www.zsh.org/)
 - Source [`setup.zsh`](https://github.com/Genki-S/PlayWithRapiro/blob/master/user/setup.zsh)
 - Play around with some commands
+
+## Development
+
+### Deploy
+
+- SSH innto Raspberry Pi
+- Add your ssh public key to `~/.ssh/authorized_keys`
+- From your host in project directory, `$ gulp rsync`

--- a/README.md
+++ b/README.md
@@ -39,3 +39,16 @@ Playing around with Rapiro
   
 ## API
 See [here](http://cylonjs.com/documentation/drivers/rapiro/).
+
+## Setup
+
+### Rapiro
+
+- SSH into Raspberry Pi
+- in `rapiro` directory, run `$ node rapiro.js`
+
+### User
+
+- Use [Zsh](http://www.zsh.org/)
+- Source [`setup.zsh`](https://github.com/Genki-S/PlayWithRapiro/blob/master/user/setup.zsh)
+- Play around with some commands

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,19 @@
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+var rsync = require('rsyncwrapper').rsync;
+
+gulp.task('rsync', function() {
+  rsync({
+    ssh: true,
+    src: './rapiro/',
+    dest: 'pi@192.168.1.239:/home/pi/rapiro',
+    recursive: true,
+    args: ['--verbose']
+  }, function(error, stdout, stderr, cmd) {
+    // notify("HELLO");
+  });
+});
+
+gulp.task('watch', function() {
+  gulp.watch('./rapiro/**/*', ['rsync']);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "PlayWithRapiro",
+  "version": "1.0.0",
+  "description": "play with rapiro",
+  "main": "rapiro/rapiro.js",
+  "dependencies": {},
+  "devDependencies": {
+    "gulp": "^3.8.9",
+    "gulp-util": "^3.0.1",
+    "rsyncwrapper": "^0.4.1"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Genki-S/PlayWithRapiro"
+  },
+  "keywords": [
+    "Rapiro"
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Genki-S/PlayWithRapiro/issues"
+  },
+  "homepage": "https://github.com/Genki-S/PlayWithRapiro"
+}

--- a/rapiro/rapiro.js
+++ b/rapiro/rapiro.js
@@ -1,4 +1,5 @@
 var Cylon = require('cylon');
+var server = require('./server');
 
 // Initialize the robot
 Cylon.robot({
@@ -23,3 +24,6 @@ Cylon.robot({
 
   }
 }).start();
+
+// Start the server
+server.start();

--- a/rapiro/rapiro.js
+++ b/rapiro/rapiro.js
@@ -7,19 +7,25 @@ Cylon.robot({
   device: {name: 'rapiro', driver: 'rapiro'},
 
   work: function(my) {
-    my['doneWalking'] = false ;
-
-    console.log("forward");
+    my['halt'] = false;
+    my['failureCount'] = 0;
 
     every(1..second(), function() {
-      if (my['doneWalking'] == false) {
-        my.rapiro.forward();
+      if (my['halt']) {
+        return;
+      }
+
+      if (my['failureCount'] < server.getRequestCount()) {
+        my['failureCount'] = server.getRequestCount()
+        my.rapiro.unhappy();
+      } else {
+        my.rapiro.stop();
       }
     });
-    after(10..seconds(), function() {
+    after(30..seconds(), function() {
       console.log("halt");
       my.rapiro.stop();
-      my['doneWalking'] = true;
+      my['halt'] = true;
     });
 
   }

--- a/rapiro/server.js
+++ b/rapiro/server.js
@@ -1,0 +1,20 @@
+var sys = require("sys");
+var http = require("http");
+
+// FIXME: is it ok to put this in global?
+var requestCount = 0;
+
+exports.getRequestCount = function() {
+  return requestCount;
+};
+
+exports.start = function() {
+  // TODO: cool routing
+  http.createServer(function(request, response) {
+    response.writeHeader(200, {"Content-Type": "text/plain"});
+    response.write("OK");
+    response.end();
+
+    requestCount += 1;
+  }).listen("8080");
+};

--- a/rapiro/server.js
+++ b/rapiro/server.js
@@ -16,5 +16,5 @@ exports.start = function() {
     response.end();
 
     requestCount += 1;
-  }).listen("8080");
+  }).listen("8888");
 };

--- a/user/setup.zsh
+++ b/user/setup.zsh
@@ -1,0 +1,15 @@
+# this file is meant to be sourced from a user's interactive zshell.
+
+# Preparation
+autoload -Uz add-zsh-hook
+
+# Environment variables
+PWRAPIRO_SERVER_HOST="http://localhost:8080"
+
+# Hooks
+function _pwrapiro_post_command_failure() {
+  if [ $? -ne 0 ]; then
+    curl $PWRAPIRO_SERVER_HOST
+  fi
+}
+add-zsh-hook precmd _pwrapiro_post_command_failure

--- a/user/setup.zsh
+++ b/user/setup.zsh
@@ -4,7 +4,7 @@
 autoload -Uz add-zsh-hook
 
 # Environment variables
-PWRAPIRO_SERVER_HOST="http://localhost:8080"
+PWRAPIRO_SERVER_HOST="http://192.168.1.239:8888"
 
 # Hooks
 function _pwrapiro_post_command_failure() {


### PR DESCRIPTION
For instructions, see README `Setup` section.

Additionally, you can use `gulp rsync` to deploy code to Rapiro.
